### PR TITLE
Fixing getVersion when compareVersion don't have the same length as version

### DIFF
--- a/Shared/src/me/devtec/shared/versioning/VersionUtils.java
+++ b/Shared/src/me/devtec/shared/versioning/VersionUtils.java
@@ -23,7 +23,7 @@ public class VersionUtils {
 		for (int i = 0; i < Math.max(primaryVersion.length, compareToVersion.length); ++i) {
 			String number = i >= primaryVersion.length ? "0" : "1" + primaryVersion[i];
 			if (compareToVersion.length <= i)
-				break;
+				return Version.NEWER_VERSION;
 			if (ParseUtils.getInt(number) > ParseUtils.getInt("1" + compareToVersion[i]))
 				return Version.NEWER_VERSION;
 			if (ParseUtils.getInt(number) < ParseUtils.getInt("1" + compareToVersion[i]))


### PR DESCRIPTION
When there was `version` longer than `compareVersion` and both of them starthed the same, the output was that versions are the same.
Example:
version = "5.4.1" and compareVersion = "5.4" --> otput SAME_VERSION